### PR TITLE
make sure keep_words is a set

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Embeddings"
 uuid = "c5bfea45-b7f1-5224-a596-15500f5db411"
 authors = ["Lyndon White"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/src/Embeddings.jl
+++ b/src/Embeddings.jl
@@ -96,7 +96,7 @@ function load_embeddings(::Type{T},
         max_vocab_size=typemax(Int),
         keep_words=Set()) where T<:EmbeddingSystem
     
-    EmbeddingTable(_load_embeddings(T, embedding_file, max_vocab_size,  keep_words)...)
+    EmbeddingTable(_load_embeddings(T, embedding_file, max_vocab_size, Set(keep_words))...)
 end
 
 end


### PR DESCRIPTION
Passing in a large vector of words to load a specific vocabulary can make the load times quite long. This change just makes sure that checking membership in `keep_words` is fast by using a set, but without adding any type restrictions to the user-facing `load_embeddings`.