### PR TITLE
use `PrecompileTools`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.jl.mem
 /docs/build/
 /docs/site/
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 AutoHashEquals = "0.2"
 DataDeps = "0.5, 0.6, 0.7"
 GoogleDrive = "0.1.0"
+PrecompileTools = "1"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,20 @@
 name = "Embeddings"
 uuid = "c5bfea45-b7f1-5224-a596-15500f5db411"
 authors = ["Lyndon White"]
-version = "0.4.2"
+version = "0.4.3"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 DataDeps = "124859b0-ceae-595e-8997-d05f6a7a8dfe"
-Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 GoogleDrive = "91feb7a0-3508-11ea-1e8e-afea2c1c9a19"
+PrecompileTools = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 AutoHashEquals = "0.2"
 DataDeps = "0.5, 0.6, 0.7"
+GoogleDrive = "0.1.0"
 julia = "1"
-GoogleDrive="0.1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/Embeddings.jl
+++ b/src/Embeddings.jl
@@ -97,12 +97,18 @@ function load_embeddings(::Type{T},
     EmbeddingTable(_load_embeddings(T, embedding_file, max_vocab_size, Set(keep_words))...)
 end
 
-@setup_workload begin
-    @compile_workload begin
-        for T in [Word2Vec, GloVe, FastText, Paragram]
-            init(T)
-        end
+function init_systems()
+    for T in [Word2Vec, GloVe, FastText, Paragram]
+        init(T)
     end
+end
+
+@setup_workload begin
+    @compile_workload init_systems()
+end
+
+function __init__()
+    init_systems()
 end
 
 end

--- a/src/Embeddings.jl
+++ b/src/Embeddings.jl
@@ -4,6 +4,7 @@ using Statistics: norm
 using DataDeps
 using AutoHashEquals
 using GoogleDrive
+using PrecompileTools
 
 export load_embeddings, language_files
 export Word2Vec, GloVe, FastText_Text, Paragram
@@ -14,12 +15,6 @@ include("glove.jl")
 include("word2vec.jl")
 include("Paragram.jl")
 include("common.jl")
-
-function __init__()
-    for T in [Word2Vec, GloVe, FastText, Paragram]
-        init(T)
-    end
-end
 
 @auto_hash_equals struct EmbeddingTable{M<:AbstractMatrix, A<:AbstractVector}
     embeddings::M
@@ -100,6 +95,14 @@ function load_embeddings(::Type{T},
         keep_words=Set()) where T<:EmbeddingSystem
     
     EmbeddingTable(_load_embeddings(T, embedding_file, max_vocab_size, Set(keep_words))...)
+end
+
+@setup_workload begin
+    @compile_workload begin
+        for T in [Word2Vec, GloVe, FastText, Paragram]
+            init(T)
+        end
+    end
 end
 
 end


### PR DESCRIPTION
`using Embeddings` takes ~ 9s due to the heavy `__init__` by moving the load to precompilation we only need to compute this making it a lighter dependency.